### PR TITLE
Support llm embedding prefix and suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ llm similar ollama-readmes -c 'utility functions'
 ```
 Add `| jq` to pipe it through [jq](https://jqlang.github.io/jq/) for pretty-printed output, or ` | jq .id` to just see the matching filenames.
 
+### Prefix and suffix support
+
+Some embedding models expect prefixed or suffixed input (for example, instruction-style or query embeddings).
+
+This plugin supports optional embedding prefixes and suffixes provided by `llm`. When a prefix or suffix is set on the embedding model, it is automatically applied before generating embeddings.
+
+Example (Python):
+
+```python
+import llm
+
+model = llm.get_embedding_model("all-minilm")
+model.prefix = "query: "
+
+embedding = model.embed("hello world")
+```
+This is useful for models that distinguish between query and document embeddings.
+
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/llm_embed_ollama.py
+++ b/llm_embed_ollama.py
@@ -22,9 +22,27 @@ class OllamaEmbeddingModel(llm.EmbeddingModel):
         self.model_id = model_id
         self._model = None
 
+    def _apply_prefix_suffix(self, text: str) -> str:
+        prefix = getattr(self, "prefix", None)
+        suffix = getattr(self, "suffix", None)
+
+        if prefix:
+            text = f"{prefix}{text}"
+        if suffix:
+            text = f"{text}{suffix}"
+        return text
+
     def embed_batch(self, texts):
         if self._model is None:
             self._model=embeddings
         # self.embeddings(model="mxbai-embed-large", prompt=d)
-        results = [self._model(model=self.model_id, prompt=text[:MAX_LENGTH])["embedding"] for text in texts]
+        processed = [
+            self._apply_prefix_suffix(text)[:MAX_LENGTH]
+            for text in texts
+        ]
+
+        results = [
+            self._model(model=self.model_id, prompt=text)["embedding"]
+            for text in processed
+        ]
         return (list(map(float, result)) for result in results)

--- a/tests/test_ollama_embed.py
+++ b/tests/test_ollama_embed.py
@@ -1,0 +1,20 @@
+import llm
+import pytest
+import os
+
+IN_GITHUB_ACTIONS = os.environ.get("GITHUB_ACTIONS") == "true"
+
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Not running on GitHub")
+def test_ollama_embed_with_prefix_changes_output():
+    model = llm.get_embedding_model("all-minilm")
+
+    # simulate llm injecting prefix
+    setattr(model, "prefix", "query: ")
+    v1 = model.embed("hello world")
+
+    # no prefix
+    setattr(model, "prefix", None)
+    v2 = model.embed("hello world")
+
+    assert len(v1) == len(v2)
+    assert v1 != v2


### PR DESCRIPTION
Adds support for optional embedding prefix and suffix provided by llm, applies these values when present while preserving existing behavior for older llm versions

fixes #1 